### PR TITLE
#207 placeholders

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,3 @@
 
 ## Installing with npm
 $ npm install --save report-configuration
-
-Navigate to the "node_modules/report-configuration" folder and copy the content of the "assets" folder to the local "assets" folder of your project.
-Finally, in the "index.html", within the "\<head>" tag, add the following line : \<script src="./assets/ckeditor/ckeditor.js"></script>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "report-configuration",
-  "version": "0.1.4",
+  "version": "0.1.7",
   "license": "MPL-2.0",
   "scripts": {
     "ng": "ng",
@@ -9,11 +9,10 @@
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e",
-    "packagr": "ng-packagr -p ng-package.json"
+    "packagr": "ng-packagr -p ng-package.json && cp -r ./src/assets ./dist/assets"
   },
   "private": false,
-  "dependencies": {
-  },
+  "dependencies": {},
   "devDependencies": {
     "@angular/cli": "~1.7.4",
     "@angular/compiler-cli": "^5.2.0",
@@ -45,8 +44,6 @@
     "protractor": "~5.1.2",
     "ts-node": "~4.1.0",
     "tslint": "~5.9.1",
-    "typescript": "~2.5.3",
-    "ng2-ckeditor": "^1.2.0",
-    "ngx-loading": "^1.0.14"
+    "typescript": "~2.5.3"
   }
 }

--- a/src/app/text-editor/shared/ckeditor-configuration.ts
+++ b/src/app/text-editor/shared/ckeditor-configuration.ts
@@ -4,6 +4,7 @@ export var ckeditorConfiguration = {
   // Todo use 'divarea' to fix the error code editor-destroy-iframe
   extraPlugins: 'widget,tabletools,imageresizerowandcolumn',
   toolbar: [
+    { name: 'custom', items: [ 'loadButton', 'saveButton' ] },
     { name: 'document', items: [ 'Print' ] },
     { name: 'clipboard', items: [ 'Undo', 'Redo' ] },
     { name: 'styles', items: [ 'Format', 'Font', 'FontSize' ] },
@@ -14,8 +15,7 @@ export var ckeditorConfiguration = {
     { name: 'paragraph', items: [ 'NumberedList', 'BulletedList', '-', 'Outdent', 'Indent', '-', 'Blockquote' ] },
     { name: 'insert', items: [ 'Image', 'Table', 'HorizontalRule' ] },
     { name: 'tools', items: [ 'Maximize' ] },
-    { name: 'editing', items: [ 'Scayt' ] },
-    { name: 'custom', items: [ 'saveButton', 'loadButton' ] }
+    { name: 'editing', items: [ 'Scayt' ] }
   ],
 
   customConfig: '',

--- a/src/app/text-editor/shared/ckeditor-configuration.ts
+++ b/src/app/text-editor/shared/ckeditor-configuration.ts
@@ -30,7 +30,7 @@ export var ckeditorConfiguration = {
 
   /*********************** File management support ***********************/
 
-  height: 800,
+  height: 735,
   width: '100%',
 
   contentsCss: ['./assets/document-editor.css'],

--- a/src/app/text-editor/text-editor.component.html
+++ b/src/app/text-editor/text-editor.component.html
@@ -5,21 +5,6 @@
   <base href="/">
 </head>
 <body>
-  <ckeditor class="text-area" [(ngModel)]="documentContent" debounce="500" [config]="editorConfiguration">
-    <ckbutton [name]="'saveButton'"
-              [command]="'saveData'"
-              (click)="saveData()"
-              [icon]="'https://png.icons8.com/ios/100/000000/save-filled.png'"
-              [label]="'Save'"
-              [toolbar]="'editing,1'">
-    </ckbutton>
-    <ckbutton [name]="'loadButton'"
-              [command]="'loadData'"
-              (click)="loadData()"
-              [icon]="'https://png.icons8.com/ios/50/000000/synchronize-filled.png'"
-              [label]="'Load Content'"
-              [toolbar]="'editing,1'">
-    </ckbutton>
-  </ckeditor>
+  <textarea id="editor"></textarea>
 </body>
 </html>

--- a/src/app/text-editor/text-editor.component.ts
+++ b/src/app/text-editor/text-editor.component.ts
@@ -1,5 +1,5 @@
 import {Component, EventEmitter, Input, OnInit, Output} from '@angular/core';
-import { ckeditorConfiguration } from './shared/ckeditor-configuration'
+import { ckeditorConfiguration } from './shared/ckeditor-configuration';
 
 
 declare const window: any;
@@ -99,5 +99,10 @@ export class TextEditorComponent implements OnInit {
 
   public loadData() {
     this.loadDataEvent.emit();
+  }
+
+  @Input()
+  public insertAtCaret(value) {
+    this.editor.insertText(value);
   }
 }

--- a/src/app/text-editor/text-editor.component.ts
+++ b/src/app/text-editor/text-editor.component.ts
@@ -1,6 +1,9 @@
 import {Component, EventEmitter, Input, OnInit, Output} from '@angular/core';
 import { ckeditorConfiguration } from './shared/ckeditor-configuration'
 
+
+declare const window: any;
+
 @Component({
   selector: 'app-text-editor',
   templateUrl: './text-editor.component.html',
@@ -12,12 +15,7 @@ export class TextEditorComponent implements OnInit {
    * Attributes
    */
   documentContentValue: string;
-  editorConfiguration = ckeditorConfiguration;
-
-  @Input()
-  get documentContent() {
-    return this.documentContentValue;
-  }
+  editor: any;
 
   /**
    * Callbacks
@@ -39,7 +37,34 @@ export class TextEditorComponent implements OnInit {
 
   constructor() { }
 
-  ngOnInit() {  }
+  ngOnInit() {
+    if (window.CKEDITOR) {
+      this.editor = window.CKEDITOR.replace('editor', ckeditorConfiguration);
+      const that = this;
+        this.editor.addCommand('saveData', {
+          exec: function (edt) {
+            that.saveData();
+          }
+        });
+        this.editor.ui.addButton('saveButton', {
+          label: 'Save',
+          command: 'saveData',
+          toolbar: 'editing,1',
+          icon: 'https://png.icons8.com/ios/100/000000/save-filled.png'
+        });
+        this.editor.addCommand('loadData', {
+          exec: function (edt) {
+            that.loadData();
+          }
+        });
+        this.editor.ui.addButton('loadButton', {
+          label: 'Load Content',
+          command: 'loadData',
+          toolbar: 'editing,1',
+          icon: 'https://png.icons8.com/ios/50/000000/synchronize-filled.png'
+        });
+    }
+  }
 
   /**
    * Getters and setters
@@ -47,7 +72,17 @@ export class TextEditorComponent implements OnInit {
 
   set documentContent(value) {
     this.documentContentValue = value;
+    if (this.editor != null) {
+      this.editor.setData(this.documentContentValue, function () {
+        this.checkDirty();  // true
+      });
+    }
     this.documentContentChange.emit(this.documentContentValue);
+  }
+
+  @Input()
+  get documentContent() {
+    return this.documentContentValue;
   }
 
 
@@ -56,6 +91,9 @@ export class TextEditorComponent implements OnInit {
    */
 
   public saveData() {
+    if (this.editor != null) {
+      this.documentContent = this.editor.getData();
+    }
     this.saveDataEvent.emit();
   }
 

--- a/src/app/text-editor/text-editor.module.ts
+++ b/src/app/text-editor/text-editor.module.ts
@@ -3,12 +3,10 @@ import { CommonModule } from '@angular/common';
 import { TextEditorComponent } from './text-editor.component';
 import { FormsModule } from '@angular/forms';
 import { HttpClientModule } from '@angular/common/http';
-import { CKEditorModule } from 'ng2-ckeditor';
 
 @NgModule({
   imports: [
     CommonModule,
-    CKEditorModule,
     HttpClientModule,
     FormsModule
   ],


### PR DESCRIPTION
Créer un lien vers le pointeur présent dans l'éditeur texte pour permettre l'insertion de placeholders. Pour ce faire, il a fallu enlever le wrapper. Ce sera aussi plus simple pour les prochaines intéractions avec d'autres plugins.